### PR TITLE
Remove redis cache

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -15,3 +15,5 @@ services:
 tooling:
   yarn:
     service: node
+config:
+  cache: false


### PR DESCRIPTION
Remove Redis cache in local development server as it was causing issues when creating Gutenberg blocks using the Abstract Class.