### PR TITLE
Lando tooling

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -15,6 +15,10 @@ services:
   node:
     type: node
 tooling:
+  node:
+    service: appserver
+  npm:
+    service: appserver
   yarn:
     service: appserver
 config:

--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,6 @@ services:
     type: node
 tooling:
   yarn:
-    service: node
+    service: appserver
 config:
   cache: false


### PR DESCRIPTION
- yarn was initially added to the node service, but the correct one is appserver
- I'm adding also node and npm to the appserver service tooling